### PR TITLE
feat: Add CRUD API for managing tools

### DIFF
--- a/lmserv/server/api.py
+++ b/lmserv/server/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import PlainTextResponse, StreamingResponse
@@ -12,12 +12,17 @@ from pydantic import BaseModel, Field
 from ..config import Config
 from .pool import WorkerPool
 from .security import api_key_auth
+from .tools import ToolManager
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Maneja el inicio y apagado de los recursos de la aplicación."""
     app.state.config = Config()
     app.state.pool = WorkerPool(app.state.config)
+    if app.state.config.tools_path:
+        app.state.tool_manager = ToolManager(app.state.config.tools_path)
+    else:
+        app.state.tool_manager = None
     await app.state.pool.start()
     yield
     if app.state.pool:
@@ -44,7 +49,7 @@ async def health(request: Request) -> str:
 
 import json
 
-# --- Tool Definitions ---
+# --- Tool Implementations ---
 def get_weather(city: str, unit: str = "celsius") -> str:
     """Placeholder for a real weather tool."""
     if "tokyo" in city.lower():
@@ -54,7 +59,7 @@ def get_weather(city: str, unit: str = "celsius") -> str:
     else:
         return json.dumps({"temperature": "20", "unit": unit})
 
-TOOLS = {
+TOOL_REGISTRY = {
     "get_weather": get_weather,
 }
 
@@ -64,6 +69,8 @@ async def chat(request: Request, req: ChatRequest) -> PlainTextResponse:
     Genera una respuesta usando un modelo de lenguaje con un posible bucle de razonamiento y uso de herramientas.
     """
     pool: WorkerPool = request.app.state.pool
+    tool_manager: ToolManager | None = request.app.state.tool_manager
+    tools = tool_manager.tools if tool_manager else {}
     worker = await pool.acquire()
 
     conversation_history = [f"User: {req.prompt}"]
@@ -89,13 +96,14 @@ async def chat(request: Request, req: ChatRequest) -> PlainTextResponse:
                     tool_name = tool_call.get("name")
                     tool_args = tool_call.get("arguments", {})
 
-                    if tool_name in TOOLS:
-                        # Ejecuta la herramienta
-                        tool_function = TOOLS[tool_name]
-                        tool_result = tool_function(**tool_args)
-
-                        # Añade el resultado a la conversación
-                        conversation_history.append(f"Tool Result: {tool_result}")
+                    if tool_name in tools and tool_name in TOOL_REGISTRY:
+                        # Execute the tool
+                        tool_function = TOOL_REGISTRY[tool_name]
+                        try:
+                            tool_result = tool_function(**tool_args)
+                            conversation_history.append(f"Tool Result: {tool_result}")
+                        except Exception as e:
+                            conversation_history.append(f"Tool Result: Error executing tool '{tool_name}': {e}")
                         continue # Siguiente vuelta del bucle
                     else:
                         # Herramienta no encontrada
@@ -113,6 +121,56 @@ async def chat(request: Request, req: ChatRequest) -> PlainTextResponse:
 
     finally:
         await pool.release(worker)
+
+# --- Endpoints for Tool Management ---
+
+class ToolSchema(BaseModel):
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+def get_tool_manager(request: Request) -> ToolManager:
+    """Dependency to get the tool manager or raise an exception if not available."""
+    if not request.app.state.tool_manager:
+        raise HTTPException(status_code=400, detail="Tool management is not enabled. Start the server with --tools option.")
+    return request.app.state.tool_manager
+
+@app.get("/tools", response_model=List[ToolSchema], dependencies=[Depends(api_key_auth)])
+async def list_tools(tm: ToolManager = Depends(get_tool_manager)):
+    """List all available tools."""
+    return tm.get_all()
+
+@app.post("/tools", response_model=ToolSchema, status_code=201, dependencies=[Depends(api_key_auth)])
+async def create_tool(tool: ToolSchema, tm: ToolManager = Depends(get_tool_manager)):
+    """Create a new tool."""
+    try:
+        created_tool = tm.add(tool.model_dump())
+        return created_tool
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+@app.get("/tools/{tool_name}", response_model=ToolSchema, dependencies=[Depends(api_key_auth)])
+async def get_tool(tool_name: str, tm: ToolManager = Depends(get_tool_manager)):
+    """Retrieve a single tool by name."""
+    tool = tm.get_one(tool_name)
+    if not tool:
+        raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' not found.")
+    return tool
+
+@app.put("/tools/{tool_name}", response_model=ToolSchema, dependencies=[Depends(api_key_auth)])
+async def update_tool(tool_name: str, tool: ToolSchema, tm: ToolManager = Depends(get_tool_manager)):
+    """Update an existing tool."""
+    updated_tool = tm.update(tool_name, tool.model_dump())
+    if not updated_tool:
+        raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' not found.")
+    return updated_tool
+
+@app.delete("/tools/{tool_name}", status_code=204, dependencies=[Depends(api_key_auth)])
+async def delete_tool(tool_name: str, tm: ToolManager = Depends(get_tool_manager)):
+    """Delete a tool by name."""
+    if not tm.delete(tool_name):
+        raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' not found.")
+    return None
 
 @app.get("/", response_class=PlainTextResponse, include_in_schema=False)
 def root() -> str:

--- a/lmserv/server/tools.py
+++ b/lmserv/server/tools.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any, Dict, List, Optional
+
+
+class ToolManager:
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self.tools = self._load()
+
+    def _load(self) -> Dict[str, Any]:
+        """Loads tool definitions from a JSON file."""
+        try:
+            with open(self.filepath, 'r') as f:
+                data = json.load(f)
+                return {tool['name']: tool for tool in data.get('tools', [])}
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def _save(self) -> None:
+        """Saves the current tools back to the JSON file."""
+        with open(self.filepath, 'w') as f:
+            json.dump({"tools": list(self.tools.values())}, f, indent=2)
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        """Returns a list of all tools."""
+        return list(self.tools.values())
+
+    def get_one(self, tool_name: str) -> Optional[Dict[str, Any]]:
+        """Retrieves a single tool by its name."""
+        return self.tools.get(tool_name)
+
+    def add(self, tool_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Adds a new tool to the collection."""
+        tool_name = tool_data.get("name")
+        if not tool_name:
+            raise ValueError("Tool name is required.")
+        if tool_name in self.tools:
+            raise ValueError(f"Tool '{tool_name}' already exists.")
+
+        self.tools[tool_name] = tool_data
+        self._save()
+        return tool_data
+
+    def update(self, tool_name: str, tool_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Updates an existing tool."""
+        if tool_name not in self.tools:
+            return None
+
+        # Ensure the name in the data matches the tool_name
+        tool_data["name"] = tool_name
+        self.tools[tool_name] = tool_data
+        self._save()
+        return tool_data
+
+    def delete(self, tool_name: str) -> bool:
+        """Deletes a tool by its name."""
+        if tool_name not in self.tools:
+            return False
+
+        del self.tools[tool_name]
+        self._save()
+        return True


### PR DESCRIPTION
This change introduces a new CRUD API for managing tools in `tools.json`.

The following endpoints have been added:
- `GET /tools`: List all available tools.
- `POST /tools`: Add a new tool.
- `GET /tools/{tool_name}`: Retrieve a specific tool.
- `PUT /tools/{tool_name}`: Update an existing tool.
- `DELETE /tools/{tool_name}`: Delete a tool.

All new endpoints are protected with API key authentication.

The server now loads tool definitions from the `tools.json` file at startup. The `/chat` endpoint has been updated to use the loaded tools and dynamically execute the correct tool function based on the tool name.

A `ToolManager` class has been created to encapsulate the logic for CRUD operations on the `tools.json` file. A `TOOL_REGISTRY` has been added to map tool names to their implementations.